### PR TITLE
GHC 7.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: haskell
-ghc: 7.8
+ghc:
+  - "7.6"
+  - "7.8"

--- a/gitrev.cabal
+++ b/gitrev.cabal
@@ -15,7 +15,7 @@ source-repository head
   location: https://github.com/acfoltzer/gitrev.git
 
 library
-  build-depends:       base >= 4.7,
+  build-depends:       base >= 4.6,
                        directory,
                        filepath,
                        template-haskell,


### PR DESCRIPTION
I managed to get it to build on GHC 7.6 by just relaxing a constraint. I also made travis build on both 7.6 and 7.8
