### PR TITLE
add commit date of the current HEAD

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -6,6 +6,7 @@ panic :: String -> a
 panic msg = error panicMsg
   where panicMsg =
           concat [ "[panic ", $(gitBranch), "@", $(gitHash)
+                 , " (", $(gitCommitDate), ")"
                  , " (", $(gitCommitCount), " commits in HEAD)"
                  , dirty, "] ", msg ]
         dirty | $(gitDirty) = " (uncommitted files present)"

--- a/src/Development/GitRev.hs
+++ b/src/Development/GitRev.hs
@@ -28,7 +28,7 @@
 -- > % cabal exec runhaskell Example.hs
 -- > Example.hs: [panic master@2702e69355c978805064543489c351b61ac6760b (6 commits in HEAD) (uncommitted files present)] oh no!
 
-module Development.GitRev (gitHash, gitBranch, gitDirty, gitCommitCount) where
+module Development.GitRev (gitHash, gitBranch, gitDirty, gitCommitCount, gitCommitDate) where
 
 import Control.Applicative
 import Control.Exception
@@ -110,3 +110,8 @@ gitDirty = do
 gitCommitCount :: ExpQ
 gitCommitCount =
   stringE =<< runGit ["rev-list", "HEAD", "--count"] "UNKNOWN"
+
+-- | Return the commit date of the current head
+gitCommitDate :: ExpQ
+gitCommitDate =
+  stringE =<< runGit ["log", "HEAD", "-1", "--format=%cd"] "UNKNOWN"


### PR DESCRIPTION
See: https://github.com/commercialhaskell/stack/issues/792#issuecomment-132201702

This adds support for `$gitCommitDate` which returns a date of the last commit as a string in the standard git format:

```
% cabal exec runhaskell Example.hs
Example.hs: [panic master@6a7018a26121ecf5657e40d48c4165d477b6e145 (Sun Sep 27 13:31:55 2015 +0200) (8 commits in HEAD)] oh no!
```
