### PR TITLE
Added function for getting the date of the last commit

### DIFF
--- a/src/Development/GitRev.hs
+++ b/src/Development/GitRev.hs
@@ -28,7 +28,12 @@
 -- > % cabal exec runhaskell Example.hs
 -- > Example.hs: [panic master@2702e69355c978805064543489c351b61ac6760b (6 commits in HEAD) (uncommitted files present)] oh no!
 
-module Development.GitRev (gitHash, gitBranch, gitDirty, gitCommitCount) where
+module Development.GitRev ( gitHash
+                          , gitBranch
+                          , gitDirty
+                          , gitCommitCount
+                          , gitLastCommitDate
+                          ) where
 
 import Control.Applicative
 import Control.Exception
@@ -110,3 +115,8 @@ gitDirty = do
 gitCommitCount :: ExpQ
 gitCommitCount =
   stringE =<< runGit ["rev-list", "HEAD", "--count"] "UNKNOWN"
+
+-- | Return the date of the latest commit
+gitLastCommitDate :: ExpQ
+gitLastCommitDate =
+  stringE =<< runGit ["log", "-1", "--format=%cd"] "UNKNOWN"


### PR DESCRIPTION
This function is in preparation for use with Stack, see commercialhaskell/stack#1062
