### PR TITLE
Move to typed quotes

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -7,11 +7,11 @@ import Development.GitRev
 panic :: String -> a
 panic msg = error panicMsg
   where panicMsg =
-          concat [ "[panic ", $(gitBranch), "@", $(gitHash)
-                 , " (", $(gitCommitDate), ")"
-                 , " (", $(gitCommitCount), " commits in HEAD)"
+          concat [ "[panic ", $$(gitBranch), "@", $$(gitHash)
+                 , " (", $$(gitCommitDate), ")"
+                 , " (", $$(gitCommitCount), " commits in HEAD)"
                  , dirty, "] ", msg ]
-        dirty | $(gitDirty) = " (uncommitted files present)"
-              | otherwise   = ""
+        dirty | $$(gitDirty) = " (uncommitted files present)"
+              | otherwise    = ""
 
 main = panic "oh no!"

--- a/gitrev.cabal
+++ b/gitrev.cabal
@@ -19,7 +19,7 @@ library
   build-depends:       base >= 4.6 && < 5,
                        directory,
                        filepath,
-                       template-haskell,
+                       template-haskell >= 2.9 && < 3,
                        process
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This allows the splices provided by `gitrev` to be included in typed
TH quotes. Moreover, they greatly clarify the interfaces.

This change should of course be accompanied by a major version bump.
