### PR TITLE
Allow for repos with code in subdirectories

### DIFF
--- a/src/Development/GitRev.hs
+++ b/src/Development/GitRev.hs
@@ -53,7 +53,7 @@ runGit args def useIdx = do
   if gitFound
     then do
       -- a lot of bookkeeping to record the right dependencies
-      pwd <- runIO getCurrentDirectory
+      pwd <- runIO getGitRoot
       let hd         = pwd </> ".git" </> "HEAD"
           index      = pwd </> ".git" </> "index"
           packedRefs = pwd </> ".git" </> "packed-refs"
@@ -84,6 +84,20 @@ runGit args def useIdx = do
           ExitSuccess   -> return (takeWhile (/= '\n') out)
           ExitFailure _ -> return def
     else return def
+
+-- | Get the root directory of the Git repo
+getGitRoot :: IO FilePath
+getGitRoot = do
+    (code, out, err) <- readProcessWithExitCode "git" args ""
+    case code of
+        ExitSuccess   -> return $ takeWhile (/= '\n') out
+        ExitFailure _ -> error $ "git rev-parse --show-toplevel failed: " ++
+                                 err
+  where
+    args =
+        [ "rev-parse"
+        , "--show-toplevel"
+        ]
 
 -- | Type to flag if the git index is used or not in a call to runGit
 data IndexUsed = IdxUsed -- ^ The git index is used


### PR DESCRIPTION
I noticed that when working on a project that had my `.cabal` file in a subdirectory, building after an updated Git commit did not trigger any code to actually rebuild. This patch changes usage of `getCurrentDirectory` to a call to `git rev-parse --show-toplevel`
