### PR TITLE
Allow ignoring untracked files when checking whether the repo is dirty

### DIFF
--- a/src/Development/GitRev.hs
+++ b/src/Development/GitRev.hs
@@ -29,7 +29,7 @@
 -- > % cabal exec runhaskell Example.hs
 -- > Example.hs: [panic master@2ae047ba5e4a6f0f3e705a43615363ac006099c1 (Mon Jan 11 11:50:59 2016 -0800) (14 commits in HEAD) (uncommitted files present)] oh no!
 
-module Development.GitRev (gitHash, gitBranch, gitDirty, gitCommitCount, gitCommitDate) where
+module Development.GitRev (gitHash, gitBranch, gitDirty, gitDirtyTracked, gitCommitCount, gitCommitDate) where
 
 import Control.Applicative
 import Control.Exception
@@ -108,6 +108,15 @@ gitBranch =
 gitDirty :: ExpQ
 gitDirty = do
   output <- runGit ["status", "--porcelain"] "" IdxUsed
+  case output of
+    "" -> conE falseName
+    _  -> conE trueName
+
+-- | Return @True@ if there are non-commited changes to tracked files
+-- present in the repository
+gitDirtyTracked :: ExpQ
+gitDirtyTracked = do
+  output <- runGit ["status", "--porcelain","--untracked-files=no"] "" IdxUsed
   case output of
     "" -> conE falseName
     _  -> conE trueName


### PR DESCRIPTION
In the latest version of `gitrev` (1.2.0), `gitDirty` will return true if there are any uncommitted changes in the git repository, regardless of whether the changed files are tracked or untracked.

For our project it would be useful to only see whether there are any uncommitted changes to _tracked_ files, as those are the most likely to affect the result of compilation. This also corresponds to the definition of `-dirty` used in the `git describe` command.
